### PR TITLE
Add Giscus comments integration and styling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,19 @@ plugins:
 mermaid:
   src: 'https://unpkg.com/mermaid@10.6.1/dist/mermaid.min.js'
 
+# Giscus comments configuration
+giscus:
+  repo: "devnomadic/devnomadic.github.io"
+  repo-id: "MDEwOlJlcG9zaXRvcnkyOTYyMjkxOTE="  # Get this from giscus.app
+  category: "General"
+  category-id: "DIC_kwDOEagZR84CtcBV"  # Get this from giscus.app
+  mapping: "pathname"
+  reactions-enabled: "1"
+  emit-metadata: "0"
+  input-position: "bottom"
+  theme: "preferred_color_scheme"
+  lang: "en"
+
 # Theme settings
 dash:
   date_format: "%b %-d, %Y"

--- a/_includes/giscus.html
+++ b/_includes/giscus.html
@@ -1,0 +1,20 @@
+{% if site.giscus and site.giscus.repo %}
+<div class="giscus-comments">
+  <script 
+    src="https://giscus.app/client.js"
+    data-repo="{{ site.giscus.repo }}"
+    data-repo-id="{{ site.giscus.repo-id }}"
+    data-category="{{ site.giscus.category }}"
+    data-category-id="{{ site.giscus.category-id }}"
+    data-mapping="{{ site.giscus.mapping }}"
+    data-strict="0"
+    data-reactions-enabled="{{ site.giscus.reactions-enabled }}"
+    data-emit-metadata="{{ site.giscus.emit-metadata }}"
+    data-input-position="{{ site.giscus.input-position }}"
+    data-theme="{{ site.giscus.theme }}"
+    data-lang="{{ site.giscus.lang }}"
+    crossorigin="anonymous"
+    async>
+  </script>
+</div>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,9 +28,9 @@ layout: default
   {{ content }}
 </div>
 
-{% if site.dash.disqus.shortname %}
+{% if site.giscus and site.giscus.repo %}
 <div class="comments">
-{% include disqus.html %}
+{% include giscus.html %}
 </div>
 {% endif %}
 

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -192,3 +192,27 @@
     margin-bottom: 0.5em;
   }
 }
+
+/* Giscus comments styling */
+.comments {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid #e8eaed;
+}
+
+.giscus-comments {
+  margin: 1rem 0;
+}
+
+/* Ensure Giscus adapts to theme */
+.giscus-frame {
+  width: 100% !important;
+  border: none;
+}
+
+/* Dark mode support for Giscus if needed */
+@media (prefers-color-scheme: dark) {
+  .comments {
+    border-top-color: #3c4043;
+  }
+}


### PR DESCRIPTION
This pull request introduces Giscus as the new commenting system for the site, replacing Disqus. It includes configuration updates, HTML template changes, and custom styling to integrate Giscus seamlessly into the site.

### Giscus Integration:

* **Configuration for Giscus**: Added Giscus configuration in `_config.yml` to enable comments, including repository details, category, theme, and other settings.
* **Giscus HTML Template**: Created a new `_includes/giscus.html` file to embed the Giscus widget dynamically based on the configuration.

### Replacement of Disqus:

* **HTML Layout Update**: Replaced the Disqus integration with Giscus in the `_layouts/post.html` file, ensuring comments are displayed using the new system.

### Styling for Giscus:

* **Custom CSS**: Added styles in `assets/css/custom.css` to ensure proper spacing, theming, and responsiveness for Giscus comments, including support for dark mode.